### PR TITLE
Update bindgen and add a whitelist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winpty-sys"
-version = "0.4.3"
+version = "0.4.4"
 description = "Rust winpty bindings"
 repository = "https://github.com/zacps/winpty"
 readme = "README.md"
@@ -23,4 +23,4 @@ winpty-agent = []
 
 [build-dependencies]
 cc = { version = "1.0", features = ["parallel"] }
-bindgen = "0.45"
+bindgen = "0.51.1"

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,12 @@ extern crate cc;
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+use std::str::from_utf8;
+
 #[cfg(feature="winpty-agent")]
 use std::fs::copy;
-use std::str::from_utf8;
+#[cfg(feature="winpty-agent")]
+use std::fs::Path;
 
 fn main() {
     // Generate version header
@@ -94,12 +97,10 @@ fn main() {
         .header("src/include/winpty.h")
         .clang_arg("-x")
         .clang_arg("c++")
-        // This breaks the bindings at the moment
-        .rustfmt_bindings(false)
-        .blacklist_type("_IMAGE_LINENUMBER")
-        .blacklist_type("_IMAGE_LINENUMBER__bindgen_ty_1")
-        .blacklist_type("IMAGE_LINENUMBER")
-        .blacklist_type("PIMAGE_LINENUMBER")
+        .rustfmt_bindings(true)
+        .whitelist_type("winpty_.*")
+        .whitelist_function("winpty_.*")
+        .whitelist_function("wcslen")
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
I couldn't get bindgen > 0.47.3 to work with the blacklist, so I switched to a whitelist.

This should help compile times as well.

Supersedes #6